### PR TITLE
Update the example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ class Test extends Component {
       <div>
         <QrReader
           delay={this.state.delay}
-          previewStyle={previewStyle}
+          style={previewStyle}
           onError={this.handleError}
           onScan={this.handleScan}
           />


### PR DESCRIPTION
Hey Thomas,
"previewStyle" prop stopped working for me after the update, then I had to dive in the code and found that you changed the prop to "style" ( in [this](https://github.com/JodusNodus/react-qr-reader/commit/05c94fc2f9cde3f05e0ebb87202681ed00fa07ca) commit) and forgot to update it in the README example.
This PR is for the same.