### PR TITLE
Exit `handleVideo` if preview element is not rendered

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -208,7 +208,7 @@ module.exports = (_temp = _class = function (_Component) {
       // Preview element hasn't been rendered so wait for it.
 
       if (!preview) {
-        setTimeout(this.handleVideo, 200, stream);
+        return setTimeout(this.handleVideo, 200, stream);
       }
 
       // Handle different browser implementations of MediaStreams as src

--- a/src/index.js
+++ b/src/index.js
@@ -167,7 +167,7 @@ module.exports = class Reader extends Component {
 
     // Preview element hasn't been rendered so wait for it.
     if (!preview) {
-      setTimeout(this.handleVideo, 200, stream)
+      return setTimeout(this.handleVideo, 200, stream)
     }
 
     // Handle different browser implementations of MediaStreams as src


### PR DESCRIPTION
Stop executing `handleVideo` if the preview element is not rendered yet.
Otherwise `handleVideo` will always end in error `Cannot read property 'srcObject' of null` at line `174`