### PR TITLE
Assume camera faces requested facingMode and mirror accordingly

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,12 @@ class Test extends Component {
 
 ### Events
 
-| Prop        | Argument         | Description                                                                                     |
-| ----------- | ---------------- | ----------------------------------------------------------------------------------------------- |
-| onScan      | `result`         | Scan event handler. Called every scan with the decoded value or `null` if no QR code was found. |
-| onError     | `Error`          | Called when an error occurs.                                                                    |
-| onLoad      | none             | Called when the component is ready for use.                                                     |
-| onImageLoad | img onLoad event | Called when the image in legacyMode is loaded.                                                  |
+| Prop        | Argument         | Description                                                                                                     |
+| ----------- | ---------------- | --------------------------------------------------------------------------------------------------------------- |
+| onScan      | `result`         | Scan event handler. Called every scan with the decoded value or `null` if no QR code was found.                 |
+| onError     | `Error`          | Called when an error occurs.                                                                                    |
+| onLoad      | `object`         | Called when the component is ready for use. Object properties are `mirrorVideo`: boolean, `streamLabel`: string |
+| onImageLoad | img onLoad event | Called when the image in legacyMode is loaded.                                                                  |
 
 ### Options
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -204,6 +204,7 @@ module.exports = (_temp = _class = function (_Component) {
     key: 'handleVideo',
     value: function handleVideo(stream) {
       var preview = this.els.preview;
+      var facingMode = this.props.facingMode;
 
       // Preview element hasn't been rendered so wait for it.
 
@@ -233,9 +234,7 @@ module.exports = (_temp = _class = function (_Component) {
 
       preview.addEventListener('loadstart', this.handleLoadStart);
 
-      var facingUserPattern = getFacingModePattern('user');
-      var isUserFacing = facingUserPattern.test(streamTrack.label);
-      this.setState({ mirrorVideo: isUserFacing });
+      this.setState({ mirrorVideo: facingMode == 'user', streamLabel: streamTrack.label });
     }
   }, {
     key: 'handleLoadStart',
@@ -243,12 +242,15 @@ module.exports = (_temp = _class = function (_Component) {
       var _props = this.props,
           delay = _props.delay,
           onLoad = _props.onLoad;
+      var _state = this.state,
+          mirrorVideo = _state.mirrorVideo,
+          streamLabel = _state.streamLabel;
 
       var preview = this.els.preview;
       preview.play();
 
       if (typeof onLoad == 'function') {
-        onLoad();
+        onLoad({ mirrorVideo: mirrorVideo, streamLabel: streamLabel });
       }
 
       if (typeof delay == 'number') {

--- a/src/index.js
+++ b/src/index.js
@@ -164,6 +164,7 @@ module.exports = class Reader extends Component {
   }
   handleVideo(stream) {
     const { preview } = this.els
+    const { facingMode } = this.props
 
     // Preview element hasn't been rendered so wait for it.
     if (!preview) {
@@ -192,17 +193,16 @@ module.exports = class Reader extends Component {
 
     preview.addEventListener('loadstart', this.handleLoadStart)
 
-    const facingUserPattern = getFacingModePattern('user')
-    const isUserFacing = facingUserPattern.test(streamTrack.label)
-    this.setState({ mirrorVideo: isUserFacing })
+    this.setState({ mirrorVideo: facingMode == 'user', streamLabel: streamTrack.label })
   }
   handleLoadStart() {
     const { delay, onLoad } = this.props
+    const { mirrorVideo, streamLabel } = this.state
     const preview = this.els.preview
     preview.play()
 
     if(typeof onLoad == 'function') {
-      onLoad()
+      onLoad({ mirrorVideo, streamLabel })
     }
 
     if (typeof delay == 'number') {


### PR DESCRIPTION
Assume camera faces requested facingMode and mirror accordingly; report mirroring and camera name in onLoad callback.
This corrects issues with non-macbook devices where the camera name cannot be used to determine if the camera is user facing.
This update will assume that the camera is facing the requested direction as supplied by the facingMode prop.

This should address issue https://github.com/JodusNodus/react-qr-reader/issues/99