### PR TITLE
Add TypeScript definitions

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,29 @@
+// Type definitions for react-qr-reader
+// Definitions by: Josiah Nunemaker josnun.com
+
+import * as React from 'react';
+
+interface LoadInfo {
+    mirrorVideo: boolean;
+    streamLabel: string;
+}
+
+interface ReaderProps {
+    onScan: (result: string | null) => any;
+    onError: (error: Error) => any;
+    onLoad?: (loadInfo: LoadInfo) => any;
+    onImageLoad?: (event: React.SyntheticEvent<HTMLImageElement, Event>) => any;
+
+    delay?: number | false;
+    facingMode?: 'user' | 'environment';
+    legacyMode?: boolean;
+    resolution?: number;
+    showViewFinder?: boolean;
+    style?: React.CSSProperties;
+    className?: string;
+    constraints?: MediaTrackConstraints;
+}
+
+declare class Reader extends React.Component<ReaderProps, any> {};
+
+export default Reader;

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "url": "https://github.com/JodusNodus/react-qr-reader/issues"
   },
   "homepage": "https://github.com/JodusNodus/react-qr-reader#readme",
+  "types": "./lib/index.d.ts",
   "devDependencies": {
     "@storybook/addon-actions": "^3.4.11",
     "@storybook/addon-links": "^3.4.11",


### PR DESCRIPTION
This PR adds a TypeScript definition file for users that use TypeScript. It also provides autocomplete for component props in supported editors (such as VS Code) 