### PR TITLE
fix(258): improve useEffect call

### DIFF
--- a/src/QrReader/hooks.ts
+++ b/src/QrReader/hooks.ts
@@ -43,7 +43,9 @@ export const useQrReader: UseQrReaderHook = ({
           }
         });
     }
+  }, [delayBetweenScanAttempts, onResult, video, videoId]);
 
+  useEffect(() => {
     return () => {
       controlsRef.current?.stop();
     };


### PR DESCRIPTION
* add missing dependencies
* add additional effect which stops the scanner when the component unmounts

Closes #258

**HINT:** 
I only tested this roughly on my Chrome (Mac) and Chrome (Android) the new expected behaviour works. Not sure about potential breaking changes or performance drops (e.g. because of missing stop calls to previous versions of `BrowserQRCodeReader`). 