### PR TITLE
[doc] Update demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # React QR Reader [![npm version](https://badge.fury.io/js/react-qr-reader.svg)](https://badge.fury.io/js/react-qr-reader) [![License: MIT](https://img.shields.io/badge/License-MIT-brightgreen.svg)](https://opensource.org/licenses/MIT) [![Known Vulnerabilities](https://snyk.io/test/github/react-qr-reader/react-qr-reader/badge.svg)](https://snyk.io/test/github/react-qr-reader/react-qr-reader)
 
-:rocket: React QR Reader component. Check out the [demo](https://react-qr-reader.github.io/react-qr-reader/).
+:rocket: React QR Reader component. Check out the [demo](https://www.thomasbilliet.com/react-qr-reader/?path=/story/browser-qr-reader--scan-code).
 
 ## Table of contents
 


### PR DESCRIPTION
 I found that the link for the demo went to a broken site, so I updated it to point to the storybook link instead, which I found to be a sufficient demo for my purposes.